### PR TITLE
fix: PR with TA, TC, TF, or DS ID always fails

### DIFF
--- a/lib/RallyValidate.js
+++ b/lib/RallyValidate.js
@@ -883,7 +883,7 @@ class RallyValidate {
           scope: {
             workspace: '/workspace/' + config.rally.workspace
           },
-          fetch: ['FormattedID', 'Name', 'Description', 'ScheduleState', 'Project', 'Connections'],
+          fetch: ['FormattedID', 'Name', 'Description', 'ScheduleState', 'State' 'Project', 'Connections'],
           query: queryUtils.where('FormattedID', '=', githubArtifact.number),
           requestOptions: {}
         })
@@ -901,7 +901,7 @@ class RallyValidate {
           statusIcon = ':heavy_exclamation_mark:'
         } else {
           const artifact = queryResponse.Results[0]
-          status = artifact.ScheduleState
+          status = artifact.ScheduleState ? artifact.ScheduleState : artifact.State
           projectName = artifact.Project._refObjectName
           validProject = (config.rally.projects.includes('Any') || config.rally.projects.includes(projectName))
           isValid = (config.rally.states.includes(status) && validProject)


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->

<!-- Link to issue if there is one --> Bug Link : [Leading and trailing underscores prevent the integration from recognizing valid rally artifacts](https://github.com/github/rally/issues/235)
Fixes # Replacing special character so that it can be captured by Rally API

<!-- Describe what the changes are -->
## Proposed Changes

-Fix to accommodate validation for rally artifacts validation in PR with Leading and trailing underscores 

## Readiness Checklist

- [ ] If this change requires documentation, it has been included in this pull request

## Reviewer Checklist

- [x] If a functional change has occurred, testing the integration has been performed
- [x] This PR has been categorized with a label (1 of `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`) for the changelog
